### PR TITLE
Update pwasm-* to newest versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,9 +11,8 @@ either = "1.5"
 tiny-keccak = "1.4"
 bincode = "1.0"
 metrohash = "1.0"
-parity-hash = { version = "1.2", features = ["serialize"] }
-bigint = { version = "4.3.0", features = ["serialize"] }
-pwasm-abi = { version = "0.1", features = ["std"] }
+pwasm-abi = { version = "0.2", features = ["std"] }
+pwasm-std = { version = "0.13" }
 
 [features]
 default = []

--- a/src/dummy.rs
+++ b/src/dummy.rs
@@ -1,4 +1,4 @@
-use parity_hash::{Address, H256};
+use pwasm_std::types::{Address, H256};
 use std::collections::HashMap;
 use std::sync::Mutex;
 
@@ -19,14 +19,14 @@ pub fn origin() -> Address {
 }
 
 pub fn write(key: &H256, val: &[u8; 32]) {
-    STORAGE_MUTEX.lock().unwrap().insert(key.0, val.clone());
+    STORAGE_MUTEX.lock().unwrap().insert(key.to_fixed_bytes(), val.clone());
 }
 
 pub fn read(key: &H256) -> [u8; 32] {
     STORAGE_MUTEX
         .lock()
         .unwrap()
-        .get(&key.0)
+        .get(key.as_bytes())
         .cloned()
         .unwrap_or([0; 32])
 }

--- a/src/environment.rs
+++ b/src/environment.rs
@@ -1,4 +1,4 @@
-use parity_hash::H256;
+use pwasm_std::types::H256;
 use std::io::{self, Cursor};
 
 pub enum Writeable<'a> {
@@ -80,7 +80,7 @@ impl Key for H256 {
         out[5] = (val << 16) as u8;
         out[6] = (val << 8) as u8;
         out[7] = val as u8;
-        H256(out)
+        H256::from(out)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,20 +23,21 @@ extern crate lazy_static;
 #[macro_use]
 extern crate serde_derive;
 
-extern crate bigint;
 extern crate bincode;
 extern crate either;
 extern crate metrohash;
-extern crate parity_hash;
+extern crate pwasm_std;
 extern crate pwasm_abi;
 extern crate serde;
 extern crate tiny_keccak;
 
-use bigint::U256;
 use environment::{Key, Value};
 use metrohash::MetroHash;
-use parity_hash::{Address, H256};
-use pwasm_abi::eth::{Sink, Stream};
+use pwasm_std::types::{Address, H256};
+use pwasm_abi::{
+    eth::{Sink, Stream},
+    types::U256,
+};
 use serde::{Deserialize, Serialize};
 use std::any::Any;
 use std::cell::{Cell, UnsafeCell};
@@ -524,8 +525,8 @@ macro_rules! impl_solidityargs_abitype {
 impl_solidityargs_abitype! {
     Vec<u8>,
     U256,
-    ::parity_hash::Address,
-    ::parity_hash::H256,
+    pwasm_std::types::Address,
+    pwasm_std::types::H256,
     u32,
     u64,
     i32,
@@ -874,7 +875,7 @@ impl_soltype!(i16, "int16");
 impl_soltype!(i32, "int32");
 impl_soltype!(i64, "int64");
 impl_soltype!(U256, "uint256");
-impl_soltype!(::parity_hash::Address, "address");
+impl_soltype!(pwasm_std::types::Address, "address");
 
 macro_rules! sol_array {
     (@capture $e:expr) => {
@@ -1336,8 +1337,8 @@ mod test {
             [(i >> 24) as u8, (i >> 16) as u8, (i >> 8) as u8, i as u8]
         }
 
-        use bigint::U256;
-        use parity_hash::Address;
+        use pwasm_abi::types::U256;
+        use pwasm_std::types::Address;
 
         messages! {
             totalSupply() -> U256;
@@ -1417,8 +1418,8 @@ mod test {
 
     #[test]
     fn erc20() {
-        use bigint::U256;
-        use parity_hash::Address;
+        use pwasm_abi::types::U256;
+        use pwasm_std::types::Address;
         use {Contract, ContractDef, Database, DummyEnv};
 
         messages! {
@@ -1471,7 +1472,7 @@ mod test {
             });
 
         let total = U256::from(1_000_000u64);
-        let transfer_to = Address::from(&[123; 160][..]);
+        let transfer_to = Address::from([123; 160]);
         let mut contract = definition.deploy(&mut env, total.clone());
 
         let total_in_contract = contract.call::<TotalSupply>(());


### PR DESCRIPTION
This PR makes fleetwood compile again.

Changes
- Remove parity-hash and bigint
- Add pwasm-std version 0.13
- Update pwasm-abi version 0.1 => 0.2

Untested: Could fix https://github.com/paritytech/fleetwood/issues/1